### PR TITLE
Support latest version of tinder gem in campfire_notifier

### DIFF
--- a/plugins/campfire_notifier/lib/campfire_notifier.rb
+++ b/plugins/campfire_notifier/lib/campfire_notifier.rb
@@ -1,16 +1,10 @@
 begin
   require 'rubygems'
-  gem 'httparty','~>0.4.3'
-rescue
-  CruiseControl::Log.fatal("Requires httparty gem ~>0.4.5, =0.4.5 and =5.0.0 don't work")
-  exit
-end
-
-begin
+  gem 'tinder', '~>1.4.1'
   require 'tinder'
 rescue LoadError
-  CruiseControl::Log.fatal("Campfire notifier: Unable to load 'tinder' gem.")
-  CruiseControl::Log.fatal("Install the tinder gem with: sudo gem install tinder")
+  CruiseControl::Log.fatal("Campfire notifier: Unable to load 'tinder' gem version ~>1.4.1")
+  CruiseControl::Log.fatal("Install the tinder gem with: sudo gem install tinder -v 1.4.1")
   exit
 end
 
@@ -26,10 +20,9 @@ class CampfireNotifier < BuilderPlugin
       return false
     end
     CruiseControl::Log.debug("Campfire notifier: connecting to #{@subdomain}")
-    @campfire = Tinder::Campfire.new(@subdomain)
-    CruiseControl::Log.debug("Campfire notifier: authenticating user: #{@username}")
+    CruiseControl::Log.debug("Campfire notifier: connecting to #{@subdomain} as user: #{@username}")
     begin
-      @campfire.login(@username, @password)
+      @campfire = Tinder::Campfire.new(@subdomain, :username => @username, :password => @password)
     rescue Tinder::Error
       CruiseControl::Log.warn("Campfire notifier: login failed, unable to notify")
       return false

--- a/plugins/campfire_notifier/test/campfire_notifier_test.rb
+++ b/plugins/campfire_notifier/test/campfire_notifier_test.rb
@@ -10,9 +10,8 @@ class CampfireNotifierTest < Test::Unit::TestCase
 
   def test_connect_should_true_for_valid_login_and_room
     campfire = mock
-    campfire.expects(:login).with('username', 'password').returns(true)
     campfire.expects(:find_room_by_name).with('room').returns(mock)
-    Tinder::Campfire.expects(:new).returns(campfire)
+    Tinder::Campfire.expects(:new).with('sub', :username => 'username', :password => 'password').returns(campfire)
 
     @notifier.username = 'username'
     @notifier.password = 'password'
@@ -21,16 +20,13 @@ class CampfireNotifierTest < Test::Unit::TestCase
   end
 
   def test_connect_should_return_false_for_invalid_login
-    campfire = mock
-    campfire.expects(:login).raises(Tinder::Error.new)
-    Tinder::Campfire.expects(:new).returns(campfire)
+    Tinder::Campfire.expects(:new).raises(Tinder::AuthenticationFailed.new)
 
     assert !@notifier.connect
   end
 
   def test_connect_should_return_false_for_invalid_room
     campfire = mock
-    campfire.expects(:login).returns(true)
     campfire.expects(:find_room_by_name).returns(nil)
     Tinder::Campfire.expects(:new).returns(campfire)
 
@@ -41,9 +37,7 @@ class CampfireNotifierTest < Test::Unit::TestCase
   end
 
   def test_should_warn_if_login_fails
-    campfire = mock
-    campfire.expects(:login).raises(Tinder::Error.new)
-    Tinder::Campfire.expects(:new).returns(campfire)
+    Tinder::Campfire.expects(:new).raises(Tinder::AuthenticationFailed.new)
     CruiseControl::Log.expects(:warn).with { |value| value =~ /login failed/ }
 
     @notifier.connect

--- a/plugins/campfire_notifier/test/test_helper.rb
+++ b/plugins/campfire_notifier/test/test_helper.rb
@@ -1,3 +1,4 @@
+require 'rubygems'
 require 'test/unit'
 require 'mocha'
 


### PR DESCRIPTION
Update campfire_notifier to support tinder's API changes for authentication. Also, forcing httparty to version 0.4.3 no longer appears to be necessary.
