### PR TITLE
Ajust the plugin to just use the campfire token and SSL

### DIFF
--- a/plugins/campfire_notifier/README.textile
+++ b/plugins/campfire_notifier/README.textile
@@ -14,8 +14,8 @@ h1. Installation
   <pre><code>
       project.campfire_notifier.subdomain = 'cruisecontrol'
       project.campfire_notifier.room = 'room'
-      project.campfire_notifier.username = 'user'
-      project.campfire_notifier.password = 'pass'
+      project.campfire_notifier.ssl = true
+      project.campfire_notifier.token = 'your campfire token'
   </code></pre>
 # Modify your project's cruise_config.rb by adding the following lines
   <pre><code>

--- a/plugins/campfire_notifier/README.textile
+++ b/plugins/campfire_notifier/README.textile
@@ -22,7 +22,7 @@ h1. Installation
     Project.configure do |project|
       ...
       begin
-        eval File.readlines("#{CRUISE_DATA_ROOT}/campfire_notifier_settings.rb").join
+        eval File.readlines("#{CRUISE_DATA_ROOT}/campfire_notifier_plugin_settings.rb").join
       rescue
         CruiseControl::Log.warn("Failed to load Campfire notifier settings")
       end

--- a/plugins/campfire_notifier/Rakefile
+++ b/plugins/campfire_notifier/Rakefile
@@ -7,7 +7,7 @@ task :default => [ :test ]
 # Run the unit tests
 Rake::TestTask.new { |t|
   t.libs << "test"
-  t.pattern = 'test/*_test.rb'
+  t.pattern = 'test/*.rb'
   t.verbose = true
   t.warning = false
 }

--- a/plugins/campfire_notifier/lib/campfire_notifier.rb
+++ b/plugins/campfire_notifier/lib/campfire_notifier.rb
@@ -1,8 +1,8 @@
 begin
   require 'rubygems'
-  gem 'httparty','~>0.4.3'
+  gem 'httparty'
 rescue
-  CruiseControl::Log.fatal("Requires httparty gem ~>0.4.5, =0.4.5 and =5.0.0 don't work")
+  CruiseControl::Log.fatal("Requires httparty gem")
   exit
 end
 
@@ -15,7 +15,7 @@ rescue LoadError
 end
 
 class CampfireNotifier < BuilderPlugin
-  attr_accessor :subdomain, :room, :username, :password, :campfire
+  attr_accessor :subdomain, :room, :ssl, :token, :campfire
 
   def initialize(project = nil)
   end
@@ -26,15 +26,8 @@ class CampfireNotifier < BuilderPlugin
       return false
     end
     CruiseControl::Log.debug("Campfire notifier: connecting to #{@subdomain}")
-    @campfire = Tinder::Campfire.new(@subdomain)
-    CruiseControl::Log.debug("Campfire notifier: authenticating user: #{@username}")
-    begin
-      @campfire.login(@username, @password)
-    rescue Tinder::Error
-      CruiseControl::Log.warn("Campfire notifier: login failed, unable to notify")
-      return false
-    end
-
+    @campfire = Tinder::Campfire.new @subdomain, :ssl => @ssl, :token => @token
+    
     CruiseControl::Log.debug("Campfire notifier: finding room: #{@room}")
     @chat_room = @campfire.find_room_by_name(@room)
   end

--- a/plugins/campfire_notifier/lib/campfire_notifier.rb
+++ b/plugins/campfire_notifier/lib/campfire_notifier.rb
@@ -30,6 +30,7 @@ class CampfireNotifier < BuilderPlugin
     
     CruiseControl::Log.debug("Campfire notifier: finding room: #{@room}")
     @chat_room = @campfire.find_room_by_name(@room)
+    connected?
   end
 
   def disconnect

--- a/plugins/campfire_notifier/lib/campfire_notifier.rb
+++ b/plugins/campfire_notifier/lib/campfire_notifier.rb
@@ -30,21 +30,16 @@ class CampfireNotifier < BuilderPlugin
     
     CruiseControl::Log.debug("Campfire notifier: finding room: #{@room}")
     @chat_room = @campfire.find_room_by_name(@room)
-    connected?
+    true
   end
 
   def disconnect
     CruiseControl::Log.debug("Campfire notifier: disconnecting from #{@subdomain}")
-    @campfire.logout if defined?(@campfire) && @campfire.logged_in?
   end
 
   def reconnect
     disconnect
     connect
-  end
-
-  def connected?
-    defined?(@campfire) && @campfire.logged_in?
   end
 
   def build_finished(build)

--- a/plugins/campfire_notifier/test/campfire_notifier_test.rb
+++ b/plugins/campfire_notifier/test/campfire_notifier_test.rb
@@ -1,52 +1,42 @@
-require File.dirname(__FILE__) + '/test_helper'
+require 'test/unit'
+require 'mocha'
+
+class BuilderPlugin; end
+class Configuration; end
+module CruiseControl; class Log; end; end
+$LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
+require 'campfire_notifier'
+
 
 class CampfireNotifierTest < Test::Unit::TestCase
   def setup
     CruiseControl::Log.stubs(:debug)
     CruiseControl::Log.stubs(:warn)
+    CruiseControl::Log.stubs(:fatal)
     @notifier = CampfireNotifier.new
     @notifier.subdomain = 'sub'
   end
 
-  def test_connect_should_true_for_valid_login_and_room
+  def test_connect_should_true_for_valid_room
     campfire = mock
-    campfire.expects(:login).with('username', 'password').returns(true)
+    campfire.expects(:logged_in?).returns(true)
     campfire.expects(:find_room_by_name).with('room').returns(mock)
     Tinder::Campfire.expects(:new).returns(campfire)
 
-    @notifier.username = 'username'
-    @notifier.password = 'password'
+    @notifier.ssl = true
+    @notifier.token = 'token'
     @notifier.room = 'room'
     assert @notifier.connect
   end
 
-  def test_connect_should_return_false_for_invalid_login
-    campfire = mock
-    campfire.expects(:login).raises(Tinder::Error.new)
-    Tinder::Campfire.expects(:new).returns(campfire)
-
-    assert !@notifier.connect
-  end
-
   def test_connect_should_return_false_for_invalid_room
     campfire = mock
-    campfire.expects(:login).returns(true)
     campfire.expects(:find_room_by_name).returns(nil)
+    campfire.expects(:logged_in?).returns(false)
     Tinder::Campfire.expects(:new).returns(campfire)
 
-    @notifier.username = 'username'
-    @notifier.password = 'password'
     @notifier.room = 'room'
     assert !@notifier.connect
-  end
-
-  def test_should_warn_if_login_fails
-    campfire = mock
-    campfire.expects(:login).raises(Tinder::Error.new)
-    Tinder::Campfire.expects(:new).returns(campfire)
-    CruiseControl::Log.expects(:warn).with { |value| value =~ /login failed/ }
-
-    @notifier.connect
   end
 
   def test_should_logout_on_disconnect_if_logged_in

--- a/plugins/campfire_notifier/test/test_helper.rb
+++ b/plugins/campfire_notifier/test/test_helper.rb
@@ -1,8 +1,0 @@
-require 'test/unit'
-require 'mocha'
-
-class BuilderPlugin; end
-class Configuration; end
-module CruiseControl; class Log; end; end
-$LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
-require 'campfire_notifier'


### PR DESCRIPTION
There was also different file names in steps 4 and 5 in the README that is fixed.

Now it is possible to use current version of httparty.
